### PR TITLE
check element content with textContent

### DIFF
--- a/generators/templates/test/element_test.html
+++ b/generators/templates/test/element_test.html
@@ -18,7 +18,7 @@
         test('it should do something RHElementy', () => {
           // you need to write tests!!!
           const <%= camelCaseName %> = document.querySelector('<%= name %>');
-          const textContent = <%= camelCaseName %>.innerText;
+          const textContent = <%= camelCaseName %>.textContent.trim();
           assert.equal(textContent, 'This is the element content.', '<%= elementName %> should do something');
         });
       });


### PR DESCRIPTION
For some reason, innerText returns "" but textContent works.  It returns linebreaks and other whitespace too though, hence the trim.