### PR TITLE
include rollup.config.js in generated templates

### DIFF
--- a/generators/index.js
+++ b/generators/index.js
@@ -116,6 +116,12 @@ module.exports = class extends Generator {
     );
 
     this.fs.copyTpl(
+      this.templatePath("rollup.config.js"),
+      this.destinationPath(`${this.props.elementName}/rollup.config.js`),
+      this.props
+    );
+
+    this.fs.copyTpl(
       this.templatePath("demo/index.html"),
       this.destinationPath(`${this.props.elementName}/demo/index.html`),
       this.props


### PR DESCRIPTION
I missed this in the last PR about UMD.  Didn't realize each file needs to be listed in the generator's index.js.