### PR TITLE
include dotfiles only for standalone elements

### DIFF
--- a/generators/index.js
+++ b/generators/index.js
@@ -254,10 +254,13 @@ module.exports = class extends Generator {
       }
     }
 
-    this.fs.copy(
-      this.templatePath(".*"),
-      this.destinationPath(`${this.props.elementName}`)
-    );
+    // only copy hidden files for standalone elements.  PFElements don't need their own copies of babel config, editorconfig, etc.
+    if (!isPfelement) {
+      this.fs.copy(
+        this.templatePath(".*"),
+        this.destinationPath(`${this.props.elementName}`)
+      );
+    }
 
     if (fs.existsSync(this.templatePath("LICENSE.txt"))) {
       this.fs.copy(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-pfelement",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-pfelement",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Yeoman generator for creating PatternFly Elements",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently the generator includes .babelrc, .editorconfig, etc, for every element.  This change removes those files from monorepo elements.  Only standalone elements need their own copies of those files.  Elements in the monorepo can rely on the monorepo's copies of those files.