### PR TITLE
fix: making it so the generator can create standalone components again

### DIFF
--- a/generators/templates/demo/standalone-index.html
+++ b/generators/templates/demo/standalone-index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title><%= elementName %> Demo</title>
-    <script type="module" src="../node_modules/<%= elementName %>/<%= elementName %>.js"></script>
+    <script type="module" src="../node_modules/<%= elementName %>/dist/<%= elementName %>.js"></script>
   </head>
   <body >
     <h1><code><%= elementName %></code></h1>

--- a/generators/templates/package.json
+++ b/generators/templates/package.json
@@ -34,7 +34,7 @@
     "dev": "../../node_modules/.bin/gulp dev",
     "test": "../../node_modules/.bin/wct --configFile ../../wct.conf.json elements/<%= elementName %>/test/"
   },<% } else { %>"scripts": {
-    "postinstall": "node scripts/postinstall.js",
+    "postinstall": "npm run build && node scripts/postinstall.js",
     "start": "npm run dev",
     "dev": "gulp dev",
     "build": "gulp",
@@ -45,11 +45,12 @@
   }],
   "license": "MIT",
   "dependencies": {
-    <% if (sassLibraryPkg) { %>"<%= sassLibraryPkg %>": "<%= pfeSassVersion %>",<% } if (isPfelement) { %>
+    <% if (sassLibraryPkg) { %>"<%= sassLibraryPkg %>": "<%= pfeSassVersion %>",
     "@patternfly/pfelement": "<%= pfelementVersion %>"<% } %>
   },<% if (!isPfelement) { %>
   "devDependencies": {
     "@webcomponents/webcomponentsjs": "^2.2.4",
+    "autoprefixer": "^9.7.4",
     "babel-core": "^6.26.3",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.7.0",
@@ -58,15 +59,22 @@
     "decomment": "^0.9.2",
     "gulp": "^4.0.0",
     "gulp-banner": "^0.1.3",
+    "gulp-clean": "^0.4.0",
+    "gulp-clean-css": "^4.2.0",
     "gulp-rename": "^1.4.0",
+    "gulp-postcss": "^8.0.0",
     "gulp-replace": "^1.0.0",
+    "gulp-sass": "^4.0.2",
     "gulp-shell": "^0.6.5",
     "node-sass": "^4.11.0",
+    "postcss-custom-properties": "^9.0.2",
     "requirejs": "^2.3.6",
     "rollup": "^0.66.6",
     "rollup-plugin-babel": "^3.0.7",
     "rollup-plugin-commonjs": "^9.1.5",
     "rollup-plugin-node-resolve": "^3.3.0",
+    "rollup-plugin-re": "^1.0.7",
+    "rollup-plugin-terser": "^5.2.0",
     "rollup-plugin-uglify": "^4.0.0",
     "strip-css-comments": "^3.0.0",
     "trim": "0.0.1",

--- a/generators/templates/scripts/gulpfile.factory.js
+++ b/generators/templates/scripts/gulpfile.factory.js
@@ -27,7 +27,7 @@ module.exports = function factory({
     `${elementName}--*.min.css.map`,
     `${elementName}.json`
   ]);
-  
+
   // Dedupe any items
   files = files.filter((item,index) => files.indexOf(item) === index);
 
@@ -37,7 +37,8 @@ module.exports = function factory({
   const replace = require("gulp-replace");
   const clean = require("gulp-clean");
   const gulpif = require("gulp-if");
-  const gulpmatch = require("gulp-match");
+  const gulpmatch = require("gulp-match");<% if (!isPfelement) { %>
+  const browserSync = require("browser-sync").create();<% } %>
 
   // Rollup
   const shell = require("gulp-shell");
@@ -307,7 +308,7 @@ ${fs
       .pipe(dest(paths.temp));
   });
 
-  task("bundle", shell.task("../../node_modules/.bin/rollup -c"));
+  <% if (isPfelement) { %>task("bundle", shell.task("../../node_modules/.bin/rollup -c"));<% } else { %>task("bundle", shell.task("./node_modules/.bin/rollup -c"));<% } %>
 
   // Delete the temp directory
   task("clean:post", () => {
@@ -339,9 +340,20 @@ ${fs
 
   task("watch", () => {
     return watch(path.join(paths.source, "*"), series("build"));
-  });
+  });<% if (!isPfelement) { %>
 
-  task("dev", parallel("build", "watch"));
+  task("browser-sync", () => {
+    browserSync.init({
+      startPath: "./demo",
+      server: {
+        baseDir: "./"
+      }
+    });
+
+    watch("dist/**").on("change", browserSync.reload);
+  });<% } %>
+
+  <% if (isPfelement) { %>task("dev", parallel("build", "watch"));<% } else { %>task("dev", parallel("build", "watch", "browser-sync"));<% } %>
 
   task("default", series("build"));
 

--- a/generators/templates/scripts/postinstall.js
+++ b/generators/templates/scripts/postinstall.js
@@ -4,19 +4,12 @@ const path = require("path");
 const pfelementPackage = require("../package.json");
 const elementName = pfelementPackage.pfelement.elementName;
 const elementPath = path.join("node_modules", elementName);
-const elementFileName = `${elementName}.js`;
-const elementFileNameMap = `${elementFileName}.map`;
-const elementFileNameUmd = `${elementName}.umd.js`;
-const elementFileNameUmdMap = `${elementFileNameUmd}.map`;
-const filesToSymLink = [elementFileName, elementFileNameMap, elementFileNameUmd, elementFileNameUmdMap];
 
 if (!fs.existsSync(elementPath)) {
   fs.mkdirSync(elementPath);
 
-  filesToSymLink.forEach(fileName => {
-    fs.symlinkSync(
-      path.join("..", "..", fileName),
-      path.join(elementPath, fileName)
-    );
-  });
+  fs.symlinkSync(
+    path.join(__dirname, "..", "dist"),
+    path.join(elementPath, "dist")
+  );
 }

--- a/generators/templates/standalone-README.md
+++ b/generators/templates/standalone-README.md
@@ -29,9 +29,9 @@ Describe any events that are accessible external to the web component. There is 
 ## Dependencies
 Describe any dependent elements or libraries here too.
 
-Make sure you have [Polyserve][polyserve] and [Web Component Tester][web-component-tester] installed.
+Make sure you have [Web Component Tester][web-component-tester] installed.
 
-    npm install -g polyserve web-component-tester
+    npm install -g web-component-tester
 
 ## Dev
 
@@ -44,9 +44,3 @@ Make sure you have [Polyserve][polyserve] and [Web Component Tester][web-compone
 ## Build
 
     npm run build
-
-## Demo
-
-From the PFElements root directory, run:
-
-    npm run demo

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/generator-pfelement",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,11 +382,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/generator-pfelement",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Yeoman generator for creating PatternFly Elements",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #59 

Testing Instructions
1.  Pull the branch down
2. Go to your desktop and create a new directory
3. cd into the new directory and run `npm link <with the location of generator-pfelement on your local>`
4. Make sure you have Yeoman and web-component-tester installed: `npm install -g yo web-component-tester`
5. Run `yo @patternfly/pfelement`
6. Answer the questions in the prompts
7. cd into the directory of the new component you created
8. Run `npm start` to make sure a web page loads with your component
9. Run `npm test` to make sure the tests pass